### PR TITLE
Changes to run aqafer in parallel

### DIFF
--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -10,13 +10,21 @@ on:
         description: Run parallel jobs
         required: true
         type: boolean
+      runner:
+        description: runner
+        required: true
+        type: choice
+        options:
+          - ubuntu-latest
+          - windows-2019
+          - macos-10.15
 
 env:  # Links to the JDK build under test and the native test libs
   USE_TESTENV_PROPERTIES: true
   
 jobs:
   setup-parallel:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runParallel == true }}
     strategy:
       fail-fast: true
@@ -39,7 +47,7 @@ jobs:
           path: ${{ github.workspace }}/aqa-tests/TKG/parallelList.mk
 
   run_aqa_parallel:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runParallel == true }}
     needs: setup-parallel
     strategy:
@@ -72,7 +80,7 @@ jobs:
           path: ./**/output_*/*.tap
 
   run_aqa:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runParallel != true }}
     strategy:
       fail-fast: false

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -26,13 +26,14 @@ jobs:
   setup-parallel:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runParallel == true }}
+    name: setup-parallel - ${{ inputs.runner }}_${{ matrix.suite }}
     strategy:
       fail-fast: true
       matrix:
         suite: [functional, openjdk, system, perf]
     steps:
       - uses: j-braley/run-aqa@v2.0.1
-        name: Generate parallelList
+        name: Generate parallelList - ${{ matrix.suite }}
         with:
           jdksource: 'customized'
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
@@ -41,7 +42,7 @@ jobs:
           run_parallel: ${{ inputs.runParallel }}
           num_machines: 4
           
-      - name: Archive parallelList
+      - name: Archive parallelList - ${{ matrix.suite }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.suite }}-parallelList.mk
@@ -51,19 +52,20 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runParallel == true }}
     needs: setup-parallel
+    name: Run AQAvit ${{ inputs.runner }} - _${{ matrix.suite }}.${{ matrix.test_list }}
     strategy:
       fail-fast: false
       matrix: 
         test_list: ['testList_0', 'testList_1', 'testList_2', 'testList_3'] # numlist is hardcoded...for now
         suite: [functional, openjdk, system, perf]
     steps:
-      - name: Download parallelList
+      - name: Download parallelList - ${{ matrix.suite }}
         uses: actions/download-artifact@v2
         with: 
           name: ${{ matrix.suite }}-parallelList.mk
           path: ./
 
-      - name: Run AQA Tests Parallel - ${{ matrix.suite }}_${{ matrix.test_list }}
+      - name: Run AQA Parallel Test - ${{ matrix.suite }}_${{ matrix.test_list }}
         uses: j-braley/run-aqa@v2.0.1
         with:
           jdksource: 'customized'

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -39,7 +39,7 @@ jobs:
           aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release'
           build_list: ${{ matrix.suite }} # parallellist to generate
           run_parallel: ${{ inputs.runParallel }}
-          num_machines: 5 # must update test list in next job..for now
+          num_machines: 4
           
       - name: Archive parallelList
         uses: actions/upload-artifact@v2
@@ -47,32 +47,30 @@ jobs:
           name: ${{ matrix.suite }}-parallelList.mk
           path: ${{ github.workspace }}/aqa-tests/TKG/parallelList.mk
 
-  run_aqa_parallel:
+  run-aqa-parallel:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.runParallel == true }}
     needs: setup-parallel
     strategy:
       fail-fast: false
-      matrix:
-        target: ['-f parallelList.mk'] 
+      matrix: 
         test_list: ['testList_0', 'testList_1', 'testList_2', 'testList_3'] # numlist is hardcoded...for now
         suite: [functional, openjdk, system, perf]
     steps:
-        # this would need to be in the dir where we run tests....
-      - name: download parallelList
+      - name: Download parallelList
         uses: actions/download-artifact@v2
         with: 
           name: ${{ matrix.suite }}-parallelList.mk
           path: ./
 
-      - name: Run AQA Tests Parallel - ${{ matrix.test_list }}
+      - name: Run AQA Tests Parallel - ${{ matrix.suite }}_${{ matrix.test_list }}
         uses: j-braley/run-aqa@v2.0.1
         with:
           jdksource: 'customized'
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
           aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release'
           build_list: ${{ matrix.suite }}
-          target : ${{ matrix.target }} ${{ matrix.test_list }}
+          target : -f parallelList.mk ${{ matrix.test_list }}
 
       - uses: actions/upload-artifact@v2
         if: always() # Always run this step (even if the tests failed)

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -39,6 +39,7 @@ jobs:
           aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
           build_list: ${{ matrix.suite }} # parallellist to generate
           run_parallel: ${{ inputs.runParallel }}
+          num_machines: 4 # must update test list in next job..for now
           
       - name: Archive parallelList
         uses: actions/upload-artifact@v2
@@ -54,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         target: ['-f parallelList.mk'] 
-        test_list: ['testList_0', 'testList_1', 'testList_2'] # numlist is hardcoded...for now
+        test_list: ['testList_0', 'testList_1', 'testList_2', 'testList_3'] # numlist is hardcoded...for now
         suite: [functional, openjdk, system, perf]
     steps:
         # this would need to be in the dir where we run tests....

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -32,7 +32,7 @@ jobs:
           build_list: ${{ matrix.suite }} # parallellist to generate
           run_parallel: ${{ inputs.runParallel }}
           
-      - name: Archive parallellist
+      - name: Archive parallelList
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.suite }}-parallelList.mk
@@ -45,15 +45,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['-f parallellist.mk'] 
+        target: ['-f parallelList.mk'] 
         test_list: ['testList_0', 'testList_1', 'testList_2'] # numlist is hardcoded...for now
         suite: [functional, openjdk, system, perf]
     steps:
         # this would need to be in the dir where we run tests....
-      - name: download parallellist
+      - name: download parallelList
         uses: actions/download-artifact@v2
         with: 
-          name: ${{ matrix.suite }}-parallellist.mk
+          name: ${{ matrix.suite }}-parallelList.mk
           path: ./
 
       - name: Run AQA Tests Parallel - ${{ matrix.test_list }}
@@ -63,12 +63,12 @@ jobs:
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
           aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
           build_list: ${{ matrix.suite }}
-          target : ${{ matrix.target }} ${{ matrix.testList }}
+          target : ${{ matrix.target }} ${{ matrix.test_list }}
 
       - uses: actions/upload-artifact@v2
         if: always() # Always run this step (even if the tests failed)
         with:
-          name: test_output_${{ matrix.test_list }}
+          name: test_output_${{ matrix.suite }}_${{ matrix.test_list }}
           path: ./**/output_*/*.tap
 
   run_aqa:

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           jdksource: 'customized'
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
-          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
+          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release'
           build_list: ${{ matrix.suite }} # parallellist to generate
           run_parallel: ${{ inputs.runParallel }}
           num_machines: 5 # must update test list in next job..for now
@@ -70,7 +70,7 @@ jobs:
         with:
           jdksource: 'customized'
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
-          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
+          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release'
           build_list: ${{ matrix.suite }}
           target : ${{ matrix.target }} ${{ matrix.test_list }}
 
@@ -98,7 +98,7 @@ jobs:
       with: 
         jdksource: 'customized'
         customizedSdkUrl: ${{ inputs.customizedSdkUrl }} 
-        aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release' # Make sure this branch is set to the latest release branch
+        aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release' # Make sure this branch is set to the latest release branch
         build_list: ${{ matrix.suite }}
         target: _${{ matrix.target }}.${{ matrix.suite }}
 

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -2,14 +2,77 @@ name: Run AQAvit
 
 on:
   workflow_dispatch: # Allows the job to be manually triggered
+    inputs:
+      customizedSdkUrl:
+         description: Download link
+         required: true
+      runParallel:
+        description: Run parallel jobs
+        required: true
+        type: boolean
 
 env:  # Links to the JDK build under test and the native test libs
   USE_TESTENV_PROPERTIES: true
-  CUSTOMIZED_SDK_URL: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.14.1_1.tar.gz
   
 jobs:
+  setup-parallel:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.runParallel == true }}
+    strategy:
+      fail-fast: true
+      matrix:
+        suite: [functional, openjdk, system, perf]
+    steps:
+      - uses: j-braley/run-aqa@v2.0.1
+        name: Generate parallelList
+        with:
+          jdksource: 'customized'
+          customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
+          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
+          build_list: ${{ matrix.suite }} # parallellist to generate
+          
+      - name: Archive parallellist
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.suite }}-parallelList.mk
+          path: /aqa-tests/TKG/parallellist.mk
+
+  run_aqa_parallel:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.runParallel == true }}
+    needs: setup-parallel
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ['-f parallellist.mk'] 
+        test_list: ['testList_0', 'testList_1', 'testList_2'] # numlist is hardcoded...for now
+        suite: [functional, openjdk, system, perf]
+    steps:
+        # this would need to be in the dir where we run tests....
+      - name: download parallellist
+        uses: actions/download-artifact@v2
+        with: 
+          name: ${{ matrix.suite }}-parallellist.mk
+          path: ./
+
+      - name: Run AQA Tests Parallel - ${{ matrix.test_list }}
+        uses: j-braley/run-aqa@v2.0.1
+        with:
+          jdksource: 'customized'
+          customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
+          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
+          build_list: ${{ matrix.suite }}
+          target : ${{ matrix.target }} ${{ matrix.testList }}
+
+      - uses: actions/upload-artifact@v2
+        if: always() # Always run this step (even if the tests failed)
+        with:
+          name: test_output_${{ matrix.test_list }}
+          path: ./**/output_*/*.tap
+
   run_aqa:
     runs-on: ubuntu-latest
+    if: ${{ inputs.runParallel != true }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,12 +83,11 @@ jobs:
             suite: functional
 
     steps:
-
     - name: Run AQA Tests - ${{ matrix.target }}.${{ matrix.suite }}
       uses: adoptium/run-aqa@v2
       with: 
         jdksource: 'customized'
-        customizedSdkUrl: ${{ env.CUSTOMIZED_SDK_URL }} 
+        customizedSdkUrl: ${{ inputs.customizedSdkUrl }} 
         aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release' # Make sure this branch is set to the latest release branch
         build_list: ${{ matrix.suite }}
         target: _${{ matrix.target }}.${{ matrix.suite }}

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           jdksource: 'customized'
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
-          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release'
+          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.4-release'
           build_list: ${{ matrix.suite }} # parallellist to generate
           run_parallel: ${{ inputs.runParallel }}
           num_machines: 4
@@ -70,7 +70,7 @@ jobs:
         with:
           jdksource: 'customized'
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
-          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release'
+          aqa-testsRepo: 'adoptium/aqa-tests:v0.9.4-release'
           build_list: ${{ matrix.suite }}
           target : -f parallelList.mk ${{ matrix.test_list }}
 
@@ -98,7 +98,7 @@ jobs:
       with: 
         jdksource: 'customized'
         customizedSdkUrl: ${{ inputs.customizedSdkUrl }} 
-        aqa-testsRepo: 'adoptium/aqa-tests:v0.9.3-release' # Make sure this branch is set to the latest release branch
+        aqa-testsRepo: 'adoptium/aqa-tests:v0.9.4-release' # Make sure this branch is set to the latest release branch
         build_list: ${{ matrix.suite }}
         target: _${{ matrix.target }}.${{ matrix.suite }}
 

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -30,6 +30,7 @@ jobs:
           customizedSdkUrl: ${{ inputs.customizedSdkUrl }}
           aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
           build_list: ${{ matrix.suite }} # parallellist to generate
+          run_parallel: ${{ inputs.runParallel }}
           
       - name: Archive parallellist
         uses: actions/upload-artifact@v2

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.suite }}-parallelList.mk
-          path: /aqa-tests/TKG/parallellist.mk
+          path: ${{ github.workspace }}/aqa-tests/TKG/parallelList.mk
 
   run_aqa_parallel:
     runs-on: ubuntu-latest

--- a/.github/workflows/aqa.yml
+++ b/.github/workflows/aqa.yml
@@ -39,7 +39,7 @@ jobs:
           aqa-testsRepo: 'adoptium/aqa-tests:v0.9.1-release'
           build_list: ${{ matrix.suite }} # parallellist to generate
           run_parallel: ${{ inputs.runParallel }}
-          num_machines: 4 # must update test list in next job..for now
+          num_machines: 5 # must update test list in next job..for now
           
       - name: Archive parallelList
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
PR for my changes to the AQAfer action. Apologies for the belated opening of this PR.

Takes inputs for download link for java binaries, select runner type, choose if one wants to run in parallel or not.

Example run with latest changes: https://github.com/j-braley/aqafer/actions/runs/2743533599

Note: this version of run-aqa points to my fork which has "special code" to pull from specific repositories for aqa verfication. If able I will make this a draft. Will include link to that PR on run-aqa.